### PR TITLE
Update code to continue working under current nighlty

### DIFF
--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -4,7 +4,6 @@
 
 use serde::Deserialize;
 use std::fmt;
-use std::path::Path;
 
 #[datatest::files("tests/test-cases", {
   // Pattern is defined via `in` operator. Every file from the `directory` above will be matched


### PR DESCRIPTION
Current nighlty chokes with an interaction with serde, where it
can't identify the appropriate type for the first argument to
`::datatest::describe`. Use turbofish to be explicit. Works both on
current nightly and `2018-12-20`.