### PR TITLE
Support both current and prior nightly `rustc`

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -168,7 +168,7 @@ fn render_data_test(desc: &DataTestDesc, rendered: &mut Vec<TestDescAndFn>) {
         };
 
         let testfn = match case.testfn {
-            DataTestFn::TestFn(testfn) => TestFn::DynTestFn(testfn),
+            DataTestFn::TestFn(testfn) => TestFn::DynTestFn(Box::new(|| testfn())),
             DataTestFn::BenchFn(benchfn) => TestFn::DynBenchFn(benchfn),
         };
 


### PR DESCRIPTION
The type of `testfn` used to be `Box<FnOnce<(), Output = ()>>` but is
now `FnBox<(), Output = ()>`. Wrap in a new closure to paper over the
difference in such a way that is both forwards and backwards
compatible.