### PR TITLE
🤷🏻‍♂️Use `ctor`-based test registration by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ Data-driven tests in Rust
 name = "datatest_stable"
 harness = false
 
-[build-dependencies]
-version_check = "0.9.1"
-
 [dependencies]
 datatest-derive = { path = "datatest-derive", version = "=0.4.0" }
 regex = "1.0.0"
@@ -36,5 +33,14 @@ members = [
 ]
 
 [features]
+# Use `#[test_case]`-based test registration (only works on nightly when `custom_test_frameworks` feature is enabled).
+# Without that feature turned on, the default test registration method is to use `ctor` crate to create a global list
+# of all tests.
+test_case_registration = []
+
+# Use very, very, very sketchy way of intercepting a test runner in Rust. Without that feature, there are two options:
+# 1. use `#![test_runner(datatest::runner)]` (nightly-only)
+# 2. use `harness = false` in `Cargo.toml` with `datatest::harness!()` macro; however, in this case care must be taken
+# to use `#[datatest::test]` instead of regular `#[test]` or otherwise tests will be silently ignored.
 unsafe_test_runner = ["region"]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,3 @@
-use version_check::Channel;
-
 fn main() {
-    let is_nightly = Channel::read().map_or(false, |ch| ch.is_nightly());
-    if is_nightly {
-        println!("cargo:rustc-cfg=feature=\"nightly\"");
-    } else {
-        println!("cargo:rustc-cfg=feature=\"stable\"");
-    }
     println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,13 +138,16 @@ pub mod __internal {
 
 pub use crate::runner::runner;
 
-#[doc(hidden)]
-#[cfg(feature = "stable")]
-pub use datatest_derive::{data_stable as data, files_stable as files, test_stable as test};
+#[cfg(not(feature = "test_case_registration"))]
+pub use datatest_derive::{
+    data_ctor_registration as data, files_ctor_registration as files,
+    test_ctor_registration as test,
+};
 
-#[doc(hidden)]
-#[cfg(feature = "nightly")]
-pub use datatest_derive::{data_nightly as data, files_nightly as files};
+#[cfg(feature = "test_case_registration")]
+pub use datatest_derive::{
+    data_test_case_registration as data, files_test_case_registration as files,
+};
 
 /// Experimental functionality.
 #[doc(hidden)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -264,6 +264,9 @@ pub struct RegistrationNode {
 static REGISTRY: AtomicPtr<RegistrationNode> = AtomicPtr::new(std::ptr::null_mut());
 
 pub fn register(new: &mut RegistrationNode) {
+    // Install interceptor that will catch invocation of `test_main_static` so we can collect all
+    // the test cases annotated with `#[test]` (built-in tests). This is needed to support regular
+    // `#[test]` tests on stable channel where we don't have a way to override test runner.
     crate::interceptor::install_interceptor();
 
     let reg = &REGISTRY;

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,0 +1,22 @@
+#![feature(custom_test_frameworks)]
+#![test_runner(datatest::runner)]
+
+// Make sure we can run tests
+
+mod inner {
+    mod another {
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        struct GreeterTestCase {
+            name: String,
+            expected: String,
+        }
+
+        #[datatest::data("tests/tests.yaml")]
+        #[test]
+        fn data_test_line_only(data: &GreeterTestCase) {
+            assert_eq!(data.expected, format!("Hi, {}!", data.name));
+        }
+    }
+}


### PR DESCRIPTION
Seems to be reliable enough and also does not require unstable feature to be turned on.