### PR TITLE
🎥Fixing name generation for regular tests

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -8,7 +8,7 @@ jobs:
   - template: ci/job-rustfmt.yml
   - template: ci/job-check.yml
     parameters:
-      toolchain: nightly
+      toolchain: nightly-2019-09-13
   - template: ci/job-test.yml
     parameters:
       name: test_stable
@@ -21,4 +21,4 @@ jobs:
   - template: ci/job-test.yml
     parameters:
       name: test_nightly
-      toolchain: nightly
+      toolchain: nightly-2019-09-13

--- a/datatest-derive/src/lib.rs
+++ b/datatest-derive/src/lib.rs
@@ -532,7 +532,8 @@ fn test_registration(channel: Registration, desc_ident: &syn::Ident) -> TokenStr
     }
 }
 
-/// Wrapper that turns on behavior that works only on nightly Rust.
+/// Replacement for the `#[test]` attribute that uses ctor-based test registration so it can be
+/// used when the whole test harness is replaced.
 #[proc_macro_attribute]
 pub fn test_ctor_registration(
     _args: proc_macro::TokenStream,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -366,7 +366,7 @@ fn render_test_descriptor(
         DatatestTestDesc::RegularTest(desc) => {
             rendered.push(TestDescAndFn {
                 desc: TestDesc {
-                    name: TestName::StaticTestName(desc.name),
+                    name: TestName::StaticTestName(real_name(desc.name)),
                     ignore: desc.ignore,
                     // FIXME: should support!
                     should_panic: desc.should_panic.into(),

--- a/tests/datatest_stable.rs
+++ b/tests/datatest_stable.rs
@@ -1,7 +1,13 @@
-#[cfg(feature = "stable")]
-
 // We want to share tests between "nightly" and "stable" suites. These have to be two different
 // suites as we set `harness = false` for the "stable" one.
 include!("tests/mod.rs");
 
 datatest::harness!();
+
+// Regular test have to use `datatest` variant of `#[test]` to work.
+use datatest::test;
+
+#[test]
+fn regular_test() {
+    assert!(true, "regular tests also work!");
+}

--- a/tests/datatest_stable_unsafe.rs
+++ b/tests/datatest_stable_unsafe.rs
@@ -1,6 +1,6 @@
 //! Run with: `cargo +stable test --features unsafe_test_runner --test datatest_stable_unsafe`
 
-#[cfg(feature = "stable")]
+#[cfg(feature = "unsafe_test_runner")]
 
 // We want to share tests between "nightly" and "stable" suites. These have to be two different
 // suites as we set `harness = false` for the "stable" one.


### PR DESCRIPTION
Fixing name generation for tests that use `#[datatest::test]` (need
to drop crate name for consistency with standard test runner).

Also, minor other fixes.