### PR TITLE
add test_type to TestDesc to compile on nightly rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1.0.84"
 serde_yaml = "0.8.7"
 yaml-rust = "0.4.2"
 ctor = "0.1.10"
+cfg-if = "0.1.10"
 region = { version = "2.1.2", optional = true }
 
 [dev-dependencies]

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -8,7 +8,7 @@ jobs:
   - template: ci/job-rustfmt.yml
   - template: ci/job-check.yml
     parameters:
-      toolchain: nightly-2019-09-13
+      toolchain: nightly-2019-10-19
   - template: ci/job-test.yml
     parameters:
       name: test_stable
@@ -21,4 +21,4 @@ jobs:
   - template: ci/job-test.yml
     parameters:
       name: test_nightly
-      toolchain: nightly-2019-09-13
+      toolchain: nightly-2019-10-19

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -8,7 +8,7 @@ jobs:
   - template: ci/job-rustfmt.yml
   - template: ci/job-check.yml
     parameters:
-      toolchain: nightly-2019-10-19
+      toolchain: nightly-2019-11-02
   - template: ci/job-test.yml
     parameters:
       name: test_stable
@@ -21,4 +21,4 @@ jobs:
   - template: ci/job-test.yml
     parameters:
       name: test_nightly
-      toolchain: nightly-2019-10-19
+      toolchain: nightly-2019-11-02

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -9,6 +9,7 @@ jobs:
   - template: ci/job-check.yml
     parameters:
       toolchain: nightly-2019-11-02
+      features: ["post_v139"]
   - template: ci/job-test.yml
     parameters:
       name: test_stable
@@ -22,3 +23,4 @@ jobs:
     parameters:
       name: test_nightly
       toolchain: nightly-2019-11-02
+      features: ["post_v139"]

--- a/ci/job-check.yml
+++ b/ci/job-check.yml
@@ -1,5 +1,6 @@
 parameters:
   toolchain: stable
+  features: []
 jobs:
   - job: check
     pool:
@@ -11,7 +12,7 @@ jobs:
           components:
             - clippy
       - script: |
-          cargo check --all --all-targets
+          cargo check --all --all-targets --features "${{ join(' ', parameters.features) }}"
         displayName: cargo check
       - script: |
           cargo clippy --all

--- a/ci/job-check.yml
+++ b/ci/job-check.yml
@@ -15,6 +15,6 @@ jobs:
           cargo check --all --all-targets --features "${{ join(' ', parameters.features) }}"
         displayName: cargo check
       - script: |
-          cargo clippy --all
+          cargo clippy --all --features "${{ join(' ', parameters.features) }}"
         displayName: cargo clippy --all
 

--- a/datatest-derive/src/lib.rs
+++ b/datatest-derive/src/lib.rs
@@ -284,6 +284,7 @@ fn files_internal(
             pattern: #pattern_idx,
             ignorefn: #ignore_func_ref,
             testfn: ::datatest::__internal::FilesTestFn::#kind(#trampoline_func_ident),
+            source_file: file!(),
         };
 
         #[automatically_derived]
@@ -523,6 +524,7 @@ fn data_internal(
             name: concat!(module_path!(), "::", #func_name_str),
             ignore: #ignore,
             describefn: #describe_func_ident,
+            source_file: file!(),
         };
 
         #[automatically_derived]
@@ -631,6 +633,7 @@ pub fn test_ctor_registration(
                 ::datatest::__internal::assert_test_result(result);
             },
             should_panic: #should_panic,
+            source_file: file!(),
         };
 
         #func_item

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,6 +11,7 @@ pub struct DataTestDesc {
     pub name: &'static str,
     pub ignore: bool,
     pub describefn: fn() -> Vec<DataTestCaseDesc<DataTestFn>>,
+    pub source_file: &'static str,
 }
 
 /// Used internally for `#[datatest::data(..)]` tests.

--- a/src/files.rs
+++ b/src/files.rs
@@ -21,6 +21,7 @@ pub struct FilesTestDesc {
     pub pattern: usize,
     pub ignorefn: Option<fn(&Path) -> bool>,
     pub testfn: FilesTestFn,
+    pub source_file: &'static str,
 }
 
 /// Trait defining conversion into a function argument. We use it to convert discovered paths

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,3 +199,20 @@ fn read_to_end(path: &Path) -> Vec<u8> {
         .unwrap_or_else(|e| panic!("cannot read test input at '{}': {}", path.display(), e));
     input
 }
+
+use crate::rustc_test::TestType;
+
+/// Helper function used internally, to mirror how rustc_test chooses a TestType.
+/// Must be called with the result of `file!()` (called in macro output) to be meaningful.
+pub fn test_type(path: &'static str) -> TestType {
+    if path.starts_with("src") {
+        // `/src` folder contains unit-tests.
+        TestType::UnitTest
+    } else if path.starts_with("tests") {
+        // `/tests` folder contains integration tests.
+        TestType::IntegrationTest
+    } else {
+        // Crate layout doesn't match expected one, test type is unknown.
+        TestType::Unknown
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,10 +200,12 @@ fn read_to_end(path: &Path) -> Vec<u8> {
     input
 }
 
+#[cfg(feature = "post_v139")]
 use crate::rustc_test::TestType;
 
 /// Helper function used internally, to mirror how rustc_test chooses a TestType.
 /// Must be called with the result of `file!()` (called in macro output) to be meaningful.
+#[cfg(feature = "post_v139")]
 pub fn test_type(path: &'static str) -> TestType {
     if path.starts_with("src") {
         // `/src` folder contains unit-tests.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,8 +1,6 @@
 use crate::data::{DataTestDesc, DataTestFn};
 use crate::files::{FilesTestDesc, FilesTestFn};
-use crate::rustc_test::{
-    Bencher, ShouldPanic, TestDesc, TestDescAndFn, TestFn, TestName, TestType,
-};
+use crate::rustc_test::{Bencher, ShouldPanic, TestDesc, TestDescAndFn, TestFn, TestName};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 
@@ -34,6 +32,7 @@ pub struct RegularTestDesc {
     pub ignore: bool,
     pub testfn: fn(),
     pub should_panic: RegularShouldPanic,
+    pub source_file: &'static str,
 }
 
 fn derive_test_name(root: &Path, path: &Path, test_name: &str) -> String {
@@ -176,7 +175,7 @@ fn render_files_test(desc: &FilesTestDesc, rendered: &mut Vec<TestDescAndFn>) {
                     should_panic: ShouldPanic::No,
                     // Cannot be used on stable: https://github.com/rust-lang/rust/issues/46488
                     allow_fail: false,
-                    test_type: TestType::IntegrationTest,
+                    test_type: crate::test_type(desc.source_file),
                 },
                 testfn,
             };
@@ -220,7 +219,7 @@ fn render_data_test(desc: &DataTestDesc, rendered: &mut Vec<TestDescAndFn>) {
                 ignore: desc.ignore,
                 should_panic: ShouldPanic::No,
                 allow_fail: false,
-                test_type: TestType::IntegrationTest,
+                test_type: crate::test_type(desc.source_file),
             },
             testfn,
         };
@@ -380,7 +379,7 @@ fn render_test_descriptor(
                     // FIXME: should support!
                     should_panic: desc.should_panic.into(),
                     allow_fail: false,
-                    test_type: TestType::IntegrationTest,
+                    test_type: crate::test_type(desc.source_file),
                 },
                 testfn: TestFn::StaticTestFn(desc.testfn),
             })

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,8 @@
 use crate::data::{DataTestDesc, DataTestFn};
 use crate::files::{FilesTestDesc, FilesTestFn};
-use crate::rustc_test::{Bencher, ShouldPanic, TestDesc, TestDescAndFn, TestFn, TestName};
+use crate::rustc_test::{
+    Bencher, ShouldPanic, TestDesc, TestDescAndFn, TestFn, TestName, TestType,
+};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 
@@ -174,6 +176,7 @@ fn render_files_test(desc: &FilesTestDesc, rendered: &mut Vec<TestDescAndFn>) {
                     should_panic: ShouldPanic::No,
                     // Cannot be used on stable: https://github.com/rust-lang/rust/issues/46488
                     allow_fail: false,
+                    test_type: TestType::IntegrationTest,
                 },
                 testfn,
             };
@@ -217,6 +220,7 @@ fn render_data_test(desc: &DataTestDesc, rendered: &mut Vec<TestDescAndFn>) {
                 ignore: desc.ignore,
                 should_panic: ShouldPanic::No,
                 allow_fail: false,
+                test_type: TestType::IntegrationTest,
             },
             testfn,
         };
@@ -376,6 +380,7 @@ fn render_test_descriptor(
                     // FIXME: should support!
                     should_panic: desc.should_panic.into(),
                     allow_fail: false,
+                    test_type: TestType::IntegrationTest,
                 },
                 testfn: TestFn::StaticTestFn(desc.testfn),
             })


### PR DESCRIPTION
Not sure if this should be more complicated, e.g.:

- use `if_rust_version` to do what the unimplemented `cfg`s would do and
enable test_type for those 6-day-old nightlies
- add macro syntax for changing the test type? (probably not necessary)
- update docs to reflect {usability with stable rust} not being itself stable?

Also obviously this is going to fail most tests