### PR TITLE
Release version 0.6.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datatest"
-version = "0.6.3-alpha.0"
+version = "0.6.4"
 authors = ["Ivan Dubrov <ivan@commure.com>"]
 edition = "2018"
 repository = "https://github.com/commure/datatest"


### PR DESCRIPTION
Bumb the version PATCH number, to make the prior bugfix available.

(I haven't actually worked with versioning in cargo before, so let me know if I'm doing something wrong.)