### PR TITLE
Fix compilation errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ use std::path::Path;
 
 /// `datatest` test harness entry point. Should be declared in the test module, like in the
 /// following snippet:
-/// ```rust,norun
+/// ```rust,no_run
 /// datatest::harness!();
 /// ```
 ///

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -255,9 +255,11 @@ fn real_name(name: &str) -> &str {
 /// instead.
 fn adjust_for_test_name(opts: &mut crate::rustc_test::TestOpts, name: &str) {
     let real_test_name = real_name(name);
-    if opts.filter_exact && opts.filter.as_ref().map_or(false, |s| s == real_test_name) {
-        opts.filter_exact = false;
-        opts.filter = Some(format!("{}::", real_test_name));
+    if opts.filter_exact {
+        if let Some(test_name_index) = opts.filters.iter().position(|s| s == real_test_name) {
+            opts.filter_exact = false;
+            opts.filters[test_name_index] = format!("{}::", real_test_name);
+        }
     }
 }
 


### PR DESCRIPTION
I love this crate — thanks for making it!

I noticed that compilation is broken with the latest nightlies.  This PR fixes these, and changes `norun` to `no_run` (this attribute name must've changed as well).  I'm not 100% on the semantic correctness here, so if something different should be done let me know.

```rust
error[E0609]: no field `filter` on type `&mut TestOpts`
   --> src/runner.rs:258:34
    |
258 |     if opts.filter_exact && opts.filter.as_ref().map_or(false, |s| s == real_test_name) {
    |                                  ^^^^^^ help: a field with a similar name exists: `filters`

error[E0609]: no field `filter` on type `&mut TestOpts`
   --> src/runner.rs:260:14
    |
260 |         opts.filter = Some(format!("{}::", real_test_name));
    |              ^^^^^^ help: a field with a similar name exists: `filters`
```