### PR TITLE
Fixes test signatures for Rust 1.69

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 #![allow(incomplete_features)]
 #![feature(specialization)]
-#![feature(termination_trait_lib)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
 //! Crate for supporting data-driven tests.


### PR DESCRIPTION
The main change is Rust test function shifting from `() -> ()` to `() -> Result<(), String>`. This wraps test generated test functions in closures which return `Ok` results.